### PR TITLE
Ensure values passed to fontSizeToPx are strings

### DIFF
--- a/controllers/stats.js
+++ b/controllers/stats.js
@@ -36,6 +36,11 @@ function parseSpecificity(selectors) {
 
 function fontSizeToPx(value) {
   var raw;
+
+  if (typeof value !== 'string') {
+    value = value.toString();
+  }
+
   raw = parseFloat(value, 10);
   if (value.match(/px$/)) {
     return raw;
@@ -167,4 +172,3 @@ module.exports = function(obj) {
   return model;
 
 };
-


### PR DESCRIPTION
Closes #121.

There are occasions where, when no units are present, a value is
passed along as an integer by cssstats. This is ultimately something that
should be handled by css-stats module, to ensure that it is passing around
the intended object types. However, it never hurts to ensure an object
is a string before calling match.