### PR TITLE
Set explicit cssstats version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "body-parser": "~1.8.1",
     "cheerio": "^0.18.0",
     "cookie-parser": "~1.3.3",
-    "cssstats": "^1.0.1",
+    "cssstats": "1.2.1",
     "cssbeautify": "^0.3.1",
     "debug": "~2.0.0",
     "express": "^4.10.2",


### PR DESCRIPTION
For the time being, I think in order to ensure the utmost stability, an
explicit cssstats version would be preferable.

Closes #123