### PR TITLE
[WIP] Incorporate more stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "body-parser": "~1.8.1",
     "cheerio": "^0.18.0",
     "cookie-parser": "~1.3.3",
-    "cssstats": "1.2.1",
+    "cssstats": "johnotander/css-statistics",
     "cssbeautify": "^0.3.1",
     "debug": "~2.0.0",
     "express": "^4.10.2",

--- a/views/stats.handlebars
+++ b/views/stats.handlebars
@@ -45,6 +45,28 @@
   </div>
 </section>
 
+<section id="selector-stats" class="mb4">
+  <h1 class="h2 m0">Selectors</h1>
+  <div class="flex flex-wrap mxn2">
+    <div class="col-6 md-col-3 p2">
+      <p class="bold lh1 m0">Ids</p>
+      <h1 class="h0 lh1 m0">{{number stats.aggregates.idSelectors }}</h1>
+    </div>
+    <div class="col-6 md-col-3 p2">
+      <p class="bold lh1 m0">Classes</p>
+      <h1 class="h0 lh1 m0">{{number stats.aggregates.classSelectors }}</h1>
+    </div>
+    <div class="col-6 md-col-3 p2">
+      <p class="bold lh1 m0">Pseudo Classes</p>
+      <h1 class="h0 lh1 m0">{{number stats.aggregates.pseudoClasses }}</h1>
+    </div>
+    <div class="col-6 md-col-3 p2">
+      <p class="bold lh1 m0">Pseudo Elements</p>
+      <h1 class="h0 lh1 m0">{{number stats.aggregates.pseudoElements }}</h1>
+    </div>
+  </div>
+</section>
+
 <section id="declarations" class="mb4">
   <h1 class="h2 m0">Total Declarations</h1>
   <div class="flex flex-wrap mxn2">
@@ -230,5 +252,3 @@
     </p>
   {{/if}}
 </section>
-
-

--- a/views/stats.handlebars
+++ b/views/stats.handlebars
@@ -43,27 +43,21 @@
     <h1 class="h00 lh1 m0">{{number stats.aggregates.properties.length }}</h1>
     <p class="h3 bold lh1 m0">Properties</p>
   </div>
-</section>
-
-<section id="selector-stats" class="mb4">
-  <h1 class="h2 m0">Selectors</h1>
-  <div class="flex flex-wrap mxn2">
-    <div class="col-6 md-col-3 p2">
-      <p class="bold lh1 m0">Ids</p>
-      <h1 class="h0 lh1 m0">{{number stats.aggregates.idSelectors }}</h1>
-    </div>
-    <div class="col-6 md-col-3 p2">
-      <p class="bold lh1 m0">Classes</p>
-      <h1 class="h0 lh1 m0">{{number stats.aggregates.classSelectors }}</h1>
-    </div>
-    <div class="col-6 md-col-3 p2">
-      <p class="bold lh1 m0">Pseudo Classes</p>
-      <h1 class="h0 lh1 m0">{{number stats.aggregates.pseudoClasses }}</h1>
-    </div>
-    <div class="col-6 md-col-3 p2">
-      <p class="bold lh1 m0">Pseudo Elements</p>
-      <h1 class="h0 lh1 m0">{{number stats.aggregates.pseudoElements }}</h1>
-    </div>
+  <div class="col-6 md-col-3 p2">
+    <h1 class="h00 lh1 m0">{{number stats.aggregates.idSelectors }}</h1>
+    <p class="h3 bold lh1 m0">IDs</p>
+  </div>
+  <div class="col-6 md-col-3 p2">
+    <h1 class="h00 lh1 m0">{{number stats.aggregates.classSelectors }}</h1>
+    <p class="h3 bold lh1 m0">Classes</p>
+  </div>
+  <div class="col-6 md-col-3 p2">
+    <h1 class="h00 lh1 m0">{{number stats.declarations.importantCount }}</h1>
+    <p class="h3 bold lh1 m0">!important</p>
+  </div>
+  <div class="col-6 md-col-3 p2">
+    <h1 class="h00 lh1 m0">{{number stats.declarations.vendorPrefixCount }}</h1>
+    <p class="h3 bold lh1 m0">Prefixes</p>
   </div>
 </section>
 


### PR DESCRIPTION
I'm opening this PR in hopes to start a conversation on the best way to begin incorporating the new data from the latest iterations on the `cssstats` module. I've added the `importantCount`, `vendorPrefixCount`, `classSelectors`, and `idSelectors`. Currently they're just tossed into the `#top-stats` div, but I'm assuming you all have a better idea as to where to put them.

What are your thoughts @mrmrs & @jxnblk? Do you have an idea as to where these stats would best be placed?

Also, over the next few days I'll be working on adding more data points through the `cssstats` module, so I will be continuing to add more content -- requiring more guidance on where the information should be located.

:beers: 
